### PR TITLE
(request :post "url" params) doesn't include the params

### DIFF
--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -44,7 +44,7 @@
 (defn query-string
   "Add a map of parameters to the query string of the request."
   [request params]
-  (update-in request [:query-string] #(append-query % params)))
+  (assoc request :query-string (encode-params params)))
 
 (defprotocol BodyEncodable
   "Types which can attach themselves to a request as a body"
@@ -95,7 +95,7 @@
                                              host)}}]
        (if params
          (case method
-           :get  (query-string req params)
+           :get  (assoc req :query-string (append-query query params))
            :post (body req params)
            req)
          req))))

--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -13,38 +13,13 @@
       (str (URLEncoder/encode (name k)) "="
            (URLEncoder/encode (str v))))))
 
-(defn- query-string
-  "Create a query string from a URI and a map of parameters."
-  [uri params]
-  (let [query (.getRawQuery uri)]
-    (if (or query params)
-      (string/join "&"
-        (remove string/blank?
-                [query (encode-params params)])))))
-
-(defn request
-  "Create a minimal valid request map from a HTTP method keyword, a string
-  containing a URI, and an optional map of parameters that will be added to
-  the query string of the URI. The URI can be relative or absolute. Relative
-  URIs are assumed to go to http://localhost."
-  ([method uri]
-     (request method uri nil))
-  ([method uri params]
-     (let [uri    (URI. uri)
-           host   (or (.getHost uri) "localhost")
-           port   (if (not= (.getPort uri) -1) (.getPort uri))
-           scheme (.getScheme uri)
-           path   (.getRawPath uri)]
-       {:server-port    (or port 80)
-        :server-name    host
-        :remote-addr    "localhost"
-        :uri            (if (string/blank? path) "/" path)
-        :query-string   (query-string uri params)
-        :scheme         (or (keyword scheme) :http)
-        :request-method method
-        :headers        {"host" (if port
-                                  (str host ":" port)
-                                  host)}})))
+(defn- append-query
+  "Encode and append a map of parameters to a url query string."
+  [query params]
+  (if (or query params)
+    (string/join "&"
+      (remove string/blank?
+              [query (encode-params params)]))))
 
 (defn header
   "Add a HTTP header to the request map."
@@ -66,6 +41,11 @@
       (assoc :content-length length)
       (header :content-length length)))
 
+(defn query-string
+  "Add a map of parameters to the query string of the request."
+  [request params]
+  (update-in request [:query-string] #(append-query % params)))
+
 (defmulti body
   "Set the body of the request. The supplied body value can be a string or
   a map of parameters to be url-encoded."
@@ -84,3 +64,34 @@
   (-> request
       (content-type "application/x-www-form-urlencoded")
       (body (encode-params params))))
+
+(defn request
+  "Create a minimal valid request map from a HTTP method keyword, a string
+  containing a URI, and an optional map of parameters that will be added to
+  the query string of the URI. The URI can be relative or absolute. Relative
+  URIs are assumed to go to http://localhost."
+  ([method uri]
+     (request method uri nil))
+  ([method uri params]
+     (let [uri    (URI. uri)
+           host   (or (.getHost uri) "localhost")
+           port   (if (not= (.getPort uri) -1) (.getPort uri))
+           scheme (.getScheme uri)
+           path   (.getRawPath uri)
+           query  (.getRawQuery uri)
+           req    {:server-port    (or port 80)
+                   :server-name    host
+                   :remote-addr    "localhost"
+                   :uri            (if (string/blank? path) "/" path)
+                   :query-string   query
+                   :scheme         (or (keyword scheme) :http)
+                   :request-method method
+                   :headers        {"host" (if port
+                                             (str host ":" port)
+                                             host)}}]
+       (if params
+         (case method
+           :get  (query-string req params)
+           :post (body req params)
+           req)
+         req))))

--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -9,9 +9,9 @@
   "Turn a map of parameters into a urlencoded string."
   [params]
   (string/join "&"
-    (for [[k v] params]
-      (str (URLEncoder/encode (name k)) "="
-           (URLEncoder/encode (str v))))))
+               (for [[k v] params]
+                 (str (URLEncoder/encode (name k)) "="
+                      (URLEncoder/encode (str v))))))
 
 (defn- query-string
   "Create a query string from a URI and a map of parameters."
@@ -19,33 +19,8 @@
   (let [query (.getRawQuery uri)]
     (if (or query params)
       (string/join "&"
-        (remove string/blank?
-                [query (encode-params params)])))))
-
-(defn request
-  "Create a minimal valid request map from a HTTP method keyword, a string
-  containing a URI, and an optional map of parameters that will be added to
-  the query string of the URI. The URI can be relative or absolute. Relative
-  URIs are assumed to go to http://localhost."
-  ([method uri]
-     (request method uri nil))
-  ([method uri params]
-     (let [uri    (URI. uri)
-           host   (or (.getHost uri) "localhost")
-           port   (if (not= (.getPort uri) -1) (.getPort uri))
-           scheme (.getScheme uri)
-           path   (.getRawPath uri)]
-       {:server-port    (or port 80)
-        :server-name    host
-        :remote-addr    "localhost"
-        :uri            (if (string/blank? path) "/" path)
-        :query-string   (query-string uri params)
-        :scheme         (or (keyword scheme) :http)
-        :request-method method
-        :headers        {"host" (if port
-                                  (str host ":" port)
-                                  host)}})))
-
+                   (remove string/blank?
+                           [query (encode-params params)])))))
 (defn header
   "Add a HTTP header to the request map."
   [request header value]
@@ -66,21 +41,53 @@
       (assoc :content-length length)
       (header :content-length length)))
 
-(defmulti body
+(defprotocol BodyEncodable
+  "Types which can attach themselves to a request as a body"
+  (encode-body-to [this request] "Attach `this` to request as the request body"))
+
+(defn body
   "Set the body of the request. The supplied body value can be a string or
   a map of parameters to be url-encoded."
-  {:arglists '([request body-value])}
-  (fn [request x] (type x)))
+  [request body]
+  (encode-body-to body request))
 
-(defmethod body String [request string]
-  (body request (.getBytes string)))
+(extend-protocol BodyEncodable
+  (class (byte-array 0))
+  (encode-body-to [byte-array request]
+    (-> request
+        (content-length (count byte-array))
+        (assoc :body (ByteArrayInputStream. byte-array))))
+  String
+  (encode-body-to [string request] (encode-body-to (.getBytes string) request))
+  Map
+  (encode-body-to [map request]
+    (encode-body-to (encode-params map)
+                    (content-type request "application/x-www-form-urlencoded"))))
 
-(defmethod body (class (byte-array 0)) [request bytes]
-  (-> request
-      (content-length (count bytes))
-      (assoc :body (ByteArrayInputStream. bytes))))
-
-(defmethod body Map [request params]
-  (-> request
-      (content-type "application/x-www-form-urlencoded")
-      (body (encode-params params))))
+(defn request
+  "Create a minimal valid request map from a HTTP method keyword, a string
+  containing a URI, and an optional map of parameters that will be added to
+  the query string of the URI. The URI can be relative or absolute. Relative
+  URIs are assumed to go to http://localhost."
+  ([method uri]
+     (request method uri nil))
+  ([method uri params]
+     (let [uri    (URI. uri)
+           host   (or (.getHost uri) "localhost")
+           port   (if (not= (.getPort uri) -1) (.getPort uri))
+           scheme (.getScheme uri)
+           path   (.getRawPath uri)
+           base-map {:server-port (or port 80)
+                     :server-name host
+                     :remote-addr "localhost"
+                     :uri (if (string/blank? path) "/" path)
+                     :scheme (or (keyword scheme) :http)
+                     :request-method method
+                     :headers {"host" (if port
+                                        (str host ":" port)
+                                        host)}}]
+       (case method
+         :get (assoc base-map :query-string (query-string uri params))
+         :post (-> base-map
+                   (assoc :query-string (query-string uri nil))
+                   (body params))))))

--- a/test/ring/mock/test/request.clj
+++ b/test/ring/mock/test/request.clj
@@ -27,7 +27,7 @@
             :headers {"host" "example.com:8443"}})))
   (testing "nil path"
     (is (= (:uri (request :get "http://example.com")) "/")))
-  (testing "added params"
+  (testing "added params in :get"
     (is (= (:query-string (request :get "/" {:x "y" :z "n"}))
            "x=y&z=n"))
     (is (= (:query-string (request :get "/?a=b" {:x "y"}))
@@ -35,7 +35,30 @@
     (is (= (:query-string (request :get "/?" {:x "y"}))
            "x=y"))
     (is (= (:query-string (request :get "/" {:x "a b"}))
-           "x=a+b"))))
+           "x=a+b")))
+  (testing "added params in :post"
+    (let [req (request :post "/" {:x "y" :z "n"})]
+      (is (= (slurp (:body req))
+             "x=y&z=n"))
+      (is (nil? (:query-string req))))
+    (let [req (request :post "/?a=b" {:x "y"})]
+      (is (= (slurp (:body req))
+             "x=y"))
+      (is (= (:query-string req)
+             "a=b")))
+    (let [req (request :post "/?" {:x "y"})]
+      (is (= (slurp (:body req))
+             "x=y"))
+      (is (= (:query-string req)
+             "")))
+    (let [req (request :post "/" {:x "a b"})]
+      (is (= (slurp (:body req))
+             "x=a+b"))
+      (is (nil? (:query-string req))))
+    (let [req (request :post "/?a=b")]
+      (is (nil? (:body req)))
+      (is (= (:query-string req)
+             "a=b")))))
 
 (deftest test-header
   (is (= (header {} "X-Foo" "Bar")

--- a/test/ring/mock/test/request.clj
+++ b/test/ring/mock/test/request.clj
@@ -16,15 +16,23 @@
             :request-method :get
             :headers {"host" "localhost"}})))
   (testing "absolute uri"
-    (is (= (request :post "https://example.com:8443/foo?bar=baz")
-           {:server-port 8443
-            :server-name "example.com"
-            :remote-addr "localhost"
-            :uri "/foo"
-            :query-string "bar=baz"
-            :scheme :https
-            :request-method :post
-            :headers {"host" "example.com:8443"}})))
+    (let [request (request :post "https://example.com:8443/foo?bar=baz" {"quux" "zot"})
+          literal-request (dissoc request :body)
+          body (:body request)]
+      (is (= literal-request
+             {:server-port 8443
+              :server-name "example.com"
+              :remote-addr "localhost"
+              :uri "/foo"
+              :query-string "bar=baz"
+              :scheme :https
+              :request-method :post
+              :content-type "application/x-www-form-urlencoded"
+              :content-length 8
+              :headers {"host" "example.com:8443"
+                        "content-type" "application/x-www-form-urlencoded"
+                        "content-length" "8"}}))
+      (is (= (slurp body) "quux=zot"))))
   (testing "nil path"
     (is (= (:uri (request :get "http://example.com")) "/")))
   (testing "added params"

--- a/test/ring/mock/test/request.clj
+++ b/test/ring/mock/test/request.clj
@@ -84,6 +84,13 @@
          {:content-length 10
           :headers {"content-length" "10"}})))
 
+(deftest test-query-string
+  (is (= (-> {}
+             (query-string {:a "b"})
+             (query-string {:c "d"})
+             :query-string)
+         "c=d")))
+
 (defn- slurp* [stream]
   (let [writer (StringWriter.)]
     (io/copy stream writer)


### PR DESCRIPTION
While doing some Clojure web development, Tim Ewald and I have had some complications using ring-mock through kerodon. After tracing the problem, we think this patch will resolve our issues. The changes in this request:
- Only feed params into query-string if the verb is get
- Feed params into the body if the verb is post
- Move some fns earlier in the file so request can use them
- Switch body from a multimethod to a protocol

We could remove the protocol impl if that's important, but felt it would be a good overall change and would include it since we were messing with body already. We updated tests to reflect the new return values of request when the verb is post.
