### PR TITLE
Support for array and hash-map values in query-string and body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .lein-failures
 .lein-plugins
 .lein-env
+.lein-repl-history

--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -9,10 +9,11 @@
   "Turn a map of parameters into a urlencoded string."
   [params]
   (letfn [(encode-pair [[k v]]
-            (if (or (list? v) (vector? v) (seq? v))
-              (map #(encode-pair [(str (name k) "[]") %]) v)
-              (str (URLEncoder/encode (name k)) "="
-                   (URLEncoder/encode (str v)))))]
+            (cond
+             (map? v) (map #(encode-pair [(str (name k) "[" (name (first %)) "]") (last %)]) v)
+             (or (list? v) (vector? v) (seq? v)) (map #(encode-pair [(str (name k) "[]") %]) v)
+             :else (str (URLEncoder/encode (name k)) "="
+                        (URLEncoder/encode (str v)))))]
     (string/join "&" (flatten (map encode-pair params)))))
 
 (defn header

--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -8,10 +8,12 @@
 (defn- encode-params
   "Turn a map of parameters into a urlencoded string."
   [params]
-  (string/join "&"
-    (for [[k v] params]
-      (str (URLEncoder/encode (name k)) "="
-           (URLEncoder/encode (str v))))))
+  (letfn [(encode-pair [[k v]]
+            (if (or (list? v) (vector? v) (seq? v))
+              (map #(encode-pair [(str (name k) "[]") %]) v)
+              (str (URLEncoder/encode (name k)) "="
+                   (URLEncoder/encode (str v)))))]
+    (string/join "&" (flatten (map encode-pair params)))))
 
 (defn header
   "Add a HTTP header to the request map."

--- a/test/ring/mock/test/request.clj
+++ b/test/ring/mock/test/request.clj
@@ -2,7 +2,8 @@
   (:use clojure.test
         ring.mock.request)
   (:require [clojure.java.io :as io])
-  (:import [java.io InputStream StringWriter]))
+  (:import [java.io InputStream StringWriter]
+           [java.net URLEncoder]))
 
 (deftest test-request
   (testing "relative uri"
@@ -45,9 +46,12 @@
     (is (= (:query-string (request :get "/" {:x "a b"}))
            "x=a+b"))
     (is (= (:query-string (request :get "/" {:x ["a" "b"]}))
-           "x%5B%5D=a&x%5B%5D=b"))
+           (format "%s=a&%s=b" (URLEncoder/encode "x[]") (URLEncoder/encode "x[]"))))
     (is (= (:query-string (request :get "/" {:x '("a" "b")}))
-           "x%5B%5D=a&x%5B%5D=b")))
+           (format "%s=a&%s=b" (URLEncoder/encode "x[]") (URLEncoder/encode "x[]"))))
+    (is (= (:query-string (request :get "/" {:x {:y {:z 1}
+                                                 :a {:b 2}}}))
+           (format "%s=1&%s=2" (URLEncoder/encode "x[y][z]") (URLEncoder/encode "x[a][b]")))))
   (testing "added params in :post"
     (let [req (request :post "/" {:x "y" :z "n"})]
       (is (= (slurp (:body req))

--- a/test/ring/mock/test/request.clj
+++ b/test/ring/mock/test/request.clj
@@ -77,7 +77,11 @@
              "a=b")))
     (let [req (request :post "/" {:x ["a" "b"]})]
       (is (= (slurp (:body req))
-             "x%5B%5D=a&x%5B%5D=b"))))
+             (format "%s=a&%s=b" (URLEncoder/encode "x[]") (URLEncoder/encode "x[]")))))
+    (let [req (request :post "/" {:x {:y {:z 1}
+                                      :a {:b 2}}})]
+      (is (= (slurp (:body req))
+             (format "%s=1&%s=2" (URLEncoder/encode "x[y][z]") (URLEncoder/encode "x[a][b]"))))))
   (testing "added params in :put"
     (let [req (request :put "/" {:x "y" :z "n"})]
       (is (= (slurp (:body req)) "x=y&z=n")))))


### PR DESCRIPTION
One of my services expect array values in request parameters (multiple parameters with the same name), something like this:

``` clojure
(let [req (-> (request :post "/search")
                 (body {:body "kontera"
                           :age true
                           :tag ["one" "two"]
                           :max-docs "10"}))
       res (web-app req)
       body (parse-string (:body res) true)]
  ;;....
)
```

I added support for it in `ring.mock.request/encode-params` and added few tests.
