### PR TITLE
Use ring-codec for form encoding

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
 (defproject ring-mock "0.1.3"
   :description "A library for creating mock Ring request maps"
-  :dependencies [[org.clojure/clojure "1.2.1"]]
+  :dependencies [[org.clojure/clojure "1.2.1"]
+                 [ring/ring-codec "1.0.0"]]
   :plugins [[codox "0.6.1"]])

--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -1,6 +1,7 @@
 (ns ring.mock.request
   "Functions to create mock request maps."
-  (:require [clojure.string :as string])
+  (:require [clojure.string :as string]
+            [ring.util.codec :as codec])
   (:import java.util.Map
            java.io.ByteArrayInputStream
            [java.net URI URLEncoder]))
@@ -8,10 +9,7 @@
 (defn- encode-params
   "Turn a map of parameters into a urlencoded string."
   [params]
-  (string/join "&"
-    (for [[k v] params]
-      (str (URLEncoder/encode (name k)) "="
-           (URLEncoder/encode (str v))))))
+  (codec/form-encode params))
 
 (defn header
   "Add a HTTP header to the request map."

--- a/test/ring/mock/test/request.clj
+++ b/test/ring/mock/test/request.clj
@@ -112,10 +112,10 @@
       (is (= (slurp (:body resp)) "Hello World"))
       (is (= (:content-length resp) 11))))
   (testing "map body"
-    (let [resp (body {} {:foo "bar"})]
+    (let [resp (body {} {:foo "bar" :fi ["fi" "fo" "fum"]})]
       (is (instance? InputStream (:body resp)))
-      (is (= (slurp (:body resp)) "foo=bar"))
-      (is (= (:content-length resp) 7))
+      (is (= (slurp (:body resp)) "foo=bar&fi=fi&fi=fo&fi=fum"))
+      (is (= (:content-length resp) 26))
       (is (= (:content-type resp)
              "application/x-www-form-urlencoded"))))
   (testing "bytes body"


### PR DESCRIPTION
This is quite similar in function to #5 from @stask - I only noticed it after I'd written this!

Rather than introducing a new implementation of the form encoding, this simply leverages ring-codec.

This doesn't actually handle nested maps, but that can either be done as a pre-step that flattens into "name[keys]" or put into ring-codec upstream so that it's available elsewhere.
