### PR TITLE
Fix for specifying querystring without extra params

### DIFF
--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -9,7 +9,8 @@
 (defn- encode-params
   "Turn a map of parameters into a urlencoded string."
   [params]
-  (codec/form-encode params))
+  (if params
+    (codec/form-encode params)))
 
 (defn header
   "Add a HTTP header to the request map."

--- a/test/ring/mock/test/request.clj
+++ b/test/ring/mock/test/request.clj
@@ -35,6 +35,9 @@
       (is (= (slurp body) "quux=zot"))))
   (testing "nil path"
     (is (= (:uri (request :get "http://example.com")) "/")))
+  (testing "only params in :get"
+    (is (= (:query-string (request :get "/?a=b"))
+           "a=b")))
   (testing "added params in :get"
     (is (= (:query-string (request :get "/" (array-map :x "y" :z "n")))
            "x=y&z=n"))


### PR DESCRIPTION
The bug was introduced in the move to ring-codec as the nil behaviour differed in form-encode

I've added a failing testcase, and then a simple fix to restore the falsy behaviour of ring-mock's encode-params.

I'm unsure whether I think codec/form-encode should blow up like it does or just return nil when passed nil, but I think it's probably ok.
